### PR TITLE
Bad channel rejection and added variables to lookupAtlases function 

### DIFF
--- a/functions/ccep_lookupAtlases.m
+++ b/functions/ccep_lookupAtlases.m
@@ -1,5 +1,5 @@
 function [electrodes_tableWithlabels] = ...
-    ccep_lookupAtlases(g,electrodes_tsv,freesurfer_dir,hemi_small,output_file,electrode_to_vertex_dist)
+    ccep_lookupAtlases(g,electrodes_tsv,freesurfer_dir,dataRootPath,hemi_small,output_file,electrode_to_vertex_dist, subj, ses_label)
 %
 % This function looks up several atlas labels for electrodes in a
 % _electrodes.tsv file
@@ -185,10 +185,11 @@ t = table(...
 % concatenate the table to what is already in loc_info
 electrodes_tableWithlabels = horzcat(loc_info,t);
 
-if ~exist(output_file,'file')
+if ~exist(fullfile(dataRootPath,['sub-' subj],['ses-' ses_label],'ieeg',...
+    ['sub-' subj '_ses-' ses_label '_' output_file]),'file')
     disp(['writing output ' output_file])
-    writetable(electrodes_tableWithlabels,output_file,...
-        'Filetype','text','Delimiter','\t'); 
+    writetable(t,fullfile(dataRootPath,['sub-' subj],['ses-' ses_label],'ieeg',...
+    ['sub-' subj '_ses-' ses_label '_' output_file]),'FileType','text','Delimiter','\t');
 else
     disp(['ERROR: can not overwrite, output file already exists ' output_file])
 end

--- a/scripts/ccep_convert_electrodes.m
+++ b/scripts/ccep_convert_electrodes.m
@@ -13,7 +13,7 @@ CCEP_dir = fullfile('/Fridge','CCEP');
 
 
 % Insert RESP and session
-sub_label = 'RESP0701';
+sub_label = 'RESP0768';
 ses_label = '1';
 
 
@@ -25,6 +25,7 @@ filename_path = fullfile(working_dir,['sub-' sub_label],['ses-' ses_label],'ieeg
 load(filename_path);
 
 % load empty electrodes.tsv to add the elecmatrix to
+% print both and their sizes to see where to implement the elecmatrix
 t = readtable(fullfile(working_dir,['sub-' sub_label],['ses-' ses_label],'ieeg',...
     ['sub-' sub_label '_ses-' ses_label '_electrodes.tsv']),...
     'FileType','text','Delimiter','\t','TreatAsEmpty',{'N/A','n/a'})
@@ -39,22 +40,29 @@ t_empty = t;
 %% Manually add the elecmatrix to the table at the right place
 
 % check both the table and elecmatrix to see where the elecmatrix should be
-% placed. 
+% placed. Place NaNs on the places that should be empty. 
 
 % add electrode X positions
 t.x(1:64) = elecmatrix(1:64,1);
-t.x(65:68) = NaN;
+t.x(65) = NaN;
+t.x(66:81) = elecmatrix(65:80,1);
+t.x(82:133) = NaN;
 
 % add electrode Y positions
 t.y(1:64) = elecmatrix(1:64,2);
-t.y(65:68) = NaN;
+t.y(65) = NaN;
+t.y(66:81) = elecmatrix(65:80,2);
+t.y(82:133) = NaN;
 
 % add electrode Z positions
 t.z(1:64) = elecmatrix(1:64,3);
-t.z(65:68) = NaN;
+t.z(65) = NaN;
+t.z(66:81) = elecmatrix(65:80,3);
+t.z(82:133) = NaN;
 
 if ~isequal(t.x,t_empty.x) 
     disp('electrodes are placed in table')
+    disp('double check "t" if elecmatrix could not be place 1-on-1 in table')
 end
 
 % Add path of bids_tsv_nan2na.m function and run

--- a/scripts/ccep_detectER_clean.m
+++ b/scripts/ccep_detectER_clean.m
@@ -197,8 +197,8 @@ end
 p1_samples_start = find(tt>0.002,1);
 p1_samples_end = find(tt>0.02,1);
 
-% N1 peak: 8 and 50 ms
-n1_samples_start = find(tt>0.008,1);
+% N1 peak: 10 and 50 ms
+n1_samples_start = find(tt>0.01,1);
 n1_samples_end = find(tt>0.05,1);
 
 % P2/N2 onset: 50 and 150 ms

--- a/scripts/ccep_detectER_clean.m
+++ b/scripts/ccep_detectER_clean.m
@@ -175,7 +175,7 @@ end
 
 % makes it possible to plot multiple CCEPs to check
 for ii = 3
-    for jj = 1:68
+    for jj = 1:56
         
         % recalculate new_signal for this ii and jj to plot
         signal_median = median(cc_epoch_sorted_avg(ii,jj,baseline_tt),3);
@@ -197,8 +197,8 @@ end
 p1_samples_start = find(tt>0.002,1);
 p1_samples_end = find(tt>0.02,1);
 
-% N1 peak: 10 and 50 ms
-n1_samples_start = find(tt>0.01,1);
+% N1 peak: 8 and 50 ms
+n1_samples_start = find(tt>0.008,1);
 n1_samples_end = find(tt>0.05,1);
 
 % P2/N2 onset: 50 and 150 ms
@@ -217,6 +217,7 @@ n2_samples_end = find(tt>0.3,1);
 % n1 amplitude, p2 sample, p2 amplitude, n2 sample, n2 amplitude]
 output_ER_all = NaN(size(cc_epoch_sorted_avg,1),size(cc_epoch_sorted_avg,2),8);
 
+% for every channel
 for ii = 1:size(cc_epoch_sorted_avg,1)
     % for every averaged stimulation
     for jj = 1:size(cc_epoch_sorted_avg,2)
@@ -385,8 +386,9 @@ end
 %% plot to test
 
 % makes it possible to plot multiple CCEPs to check
-for ii = 1:size(cc_epoch_sorted_avg,1) % measured channels
-    for jj = 2 % stimulated electrode pair
+figure()
+for ii = 1:10%:size(cc_epoch_sorted_avg,1) % measured channels
+    for jj = 1:44 % stimulated electrode pair
         
         if ~isnan(output_ER_all(ii,jj,3)) % exclude this if, to see how the ones without N1 look 
             
@@ -395,13 +397,13 @@ for ii = 1:size(cc_epoch_sorted_avg,1) % measured channels
             new_signal = squeeze(cc_epoch_sorted_avg(ii,jj,:)) - signal_median;
             
             %plot((find(tt>-0.1,1)+extrasamps:find(tt>0.3,1)),new_signal(find(tt>-0.1,1)+extrasamps:find(tt>0.3,1)))
-            plot((find(tt>-0.01,1)+extrasamps:find(tt>0.1,1)),new_signal(find(tt>-0.01,1)+extrasamps:find(tt>=0.1,1)))
+            plot((find(tt>-0.01,1)+extrasamps:find(tt>0.5,1)),new_signal(find(tt>-0.01,1)+extrasamps:find(tt>=0.5,1)))
             hold on
             
             plot(output_ER_all(ii,jj,1),output_ER_all(ii,jj,2),'b*')
             plot(output_ER_all(ii,jj,3),output_ER_all(ii,jj,4),'r*')
             plot(output_ER_all(ii,jj,5),output_ER_all(ii,jj,6),'g*')
-            %plot(output_ER_all(ii,jj,7),output_ER_all(ii,jj,8),'y*')
+            plot(output_ER_all(ii,jj,7),output_ER_all(ii,jj,8),'y*')
             
             xlabel('sample')
             ylabel('amplitude(uV)')
@@ -422,7 +424,7 @@ hemi_cap = {'R'};
 v_dirs = [90 0]; %;90 0;90 -60;270 -60;0 0];
 
 % set stimulated pair you want to render
-stim_pair = 2;
+stim_pair = 1;
 
 % select significant peaks in the other channels
 n1_plot = squeeze(output_ER_all(:,stim_pair,3:4)); % measured electrodes X latency/ampl of N1 peak

--- a/scripts/validator_detectERscript.m
+++ b/scripts/validator_detectERscript.m
@@ -15,7 +15,7 @@ addpath(genpath('/Fridge/users/jaap/github/ccep/functions'))
 
 
 %% set defined parameters
-% pre-allocation: variables determined in Dorien's thesis
+% pre-allocation: variables determined in Dorien's paper
 thresh = 2.5;   %
 minSD = 50;     % in microV: minimum standard deviation of prestimulus baseline in case actual std of prestim baseline is too small
 sel = 20;       % how many samples around peak not considered as another peak
@@ -54,7 +54,7 @@ output_ER_all = NaN(size(cc_epoch_sorted_avg,1),size(cc_epoch_sorted_avg,2),8);
 validation_matrix = NaN(size(cc_epoch_sorted_avg,1),size(cc_epoch_sorted_avg,2),2);
 
 % for every channel
-for ii = 2:size(cc_epoch_sorted_avg,1)
+for ii = 1:size(cc_epoch_sorted_avg,1)
     % for every averaged stimulation
     for jj = 1:size(cc_epoch_sorted_avg,2)
         
@@ -232,7 +232,7 @@ for ii = 2:size(cc_epoch_sorted_avg,1)
         
         xlabel('time(s)')
         ylabel('amplitude(uV)')
-        title(['elec ' data_hdr.label{ccep_elec} ' for stimulation of ' data_hdr.label{cc_stimsets(jj,1)} ' and ' data_hdr.label{cc_stimsets(jj,2)} ])
+        title(['elec ' data_hdr.label{ii} ' for stimulation of ' data_hdr.label{cc_stimsets(jj,1)} ' and ' data_hdr.label{cc_stimsets(jj,2)} ])
         ylim([-1000 1000])
         
         hold on
@@ -284,7 +284,7 @@ for ii = 2:size(cc_epoch_sorted_avg,1)
     % possible
     working_dir = fullfile('/Fridge','users','jaap','ccep','dataBIDS');
     save([fullfile(working_dir,['sub-' sub_label],['ses-' ses_label],'ieeg',...
-    ['sub-' sub_label '_ses-' ses_label '_run-' run_label 'validation_matrix.mat'])],...
+    ['sub-' sub_label '_ses-' ses_label '_run-' run_label '_validation_matrix.mat'])],...
     'validation_matrix')
     
     


### PR DESCRIPTION
This pull request contains:

- bad channel rejection in master_preprocess. When there are artifacts, these data are changed to NaN. When there are NaNs within the crucial range of an epoch (1 second before stimulation, for calculating SD, till 0.5 second after stimulation), the epoch will be rejected. Because of nanmean, averaged epochs will still be calculated.
- Added variables to ccep_lookupAtlases, so the function automatically searches and saves in the right folders. 
- Some small adjustments and extra comments in other files

